### PR TITLE
Update dataset cache default endpoint to HTTPS

### DIFF
--- a/src/ptych/data/download/dataset_cache.py
+++ b/src/ptych/data/download/dataset_cache.py
@@ -23,7 +23,7 @@ DEFAULT_DOWNLOAD_MAX_ATTEMPTS = 3
 DEFAULT_DOWNLOAD_RETRY_DELAY_SECONDS = 5
 
 TRANSIENT_DOWNLOAD_ERRORS = (ConnectionResetError, ConnectionError, TimeoutError, OSError)
-DEFAULT_NEXTCLOUD_BASE_URL = "http://dqe.asuscomm.com:8080"
+DEFAULT_NEXTCLOUD_BASE_URL = "https://dqe.asuscomm.com"
 DEFAULT_NEXTCLOUD_SHARE_ID = "SLbNBTqK9firqZM"
 
 type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]


### PR DESCRIPTION
### Motivation
- Migrate the default public dataset repository endpoint to the secure host `https://dqe.asuscomm.com` so dataset downloads use HTTPS by default.

### Description
- Change `DEFAULT_NEXTCLOUD_BASE_URL` in `src/ptych/data/download/dataset_cache.py` from `http://dqe.asuscomm.com:8080` to `https://dqe.asuscomm.com`, leaving `DEFAULT_NEXTCLOUD_SHARE_ID` (`SLbNBTqK9firqZM`) unchanged.

### Testing
- Ran `pytest -q` which reported no tests were collected in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9439aa64832ca7b22da46fb3803a)