### PR TITLE
Fix darkfield reconstruction artifacts

### DIFF
--- a/reconstruction_demo.py
+++ b/reconstruction_demo.py
@@ -19,7 +19,7 @@ PUPIL_AMPLITUDE_RADIAL_ORDER = 0
 # Optimization and runtime settings
 TORCH_DEVICE = "mps"  # Switch to "cpu" or "cuda".
 PATCH_BATCH_SIZE = 16
-EPOCHS = 750
+EPOCHS = 1000
 
 # Output directory
 OUTPUT_DIR = Path(f"results/{dataset}")

--- a/reconstruction_demo.py
+++ b/reconstruction_demo.py
@@ -19,7 +19,7 @@ PUPIL_AMPLITUDE_RADIAL_ORDER = 0
 # Optimization and runtime settings
 TORCH_DEVICE = "mps"  # Switch to "cpu" or "cuda".
 PATCH_BATCH_SIZE = 16
-EPOCHS = 1000
+EPOCHS = 500
 
 # Output directory
 OUTPUT_DIR = Path(f"results/{dataset}")

--- a/reconstruction_demo.py
+++ b/reconstruction_demo.py
@@ -21,61 +21,9 @@ TORCH_DEVICE = "mps"  # Switch to "cpu" or "cuda".
 PATCH_BATCH_SIZE = 16
 EPOCHS = 100
 
-# MTF-preserving display/output sharpening after the artifact-suppressed solve.
-EDGE_SHARPEN_THRESHOLD_PERCENTILE = 90
-EDGE_SHARPEN_SIGMA_PX = 3.0
-EDGE_SHARPEN_AMOUNT = 2.25
-EDGE_MASK_SIGMA_PX = 1.0
-EDGE_MASK_SLOPE = 8.0
-
 # Output directory
 OUTPUT_DIR = Path(f"results/{dataset}")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def _fft_gaussian_blur(image: np.ndarray, sigma_px: float) -> np.ndarray:
-    height, width = image.shape
-    fy = np.fft.fftfreq(height)
-    fx = np.fft.fftfreq(width)
-    y_frequency, x_frequency = np.meshgrid(fy, fx, indexing="ij")
-    gaussian = np.exp(
-        -2.0
-        * np.pi**2
-        * sigma_px**2
-        * (np.square(x_frequency) + np.square(y_frequency))
-    )
-    return np.fft.ifft2(np.fft.fft2(image) * gaussian).real
-
-
-def _edge_sharpen_object(object_array: np.ndarray) -> np.ndarray:
-    object_intensity = np.square(np.abs(object_array))
-    low_clip, high_clip = np.percentile(object_intensity, [0.1, 99.9])
-
-    edge_base = _fft_gaussian_blur(object_intensity, EDGE_MASK_SIGMA_PX)
-    y_gradient, x_gradient = np.gradient(edge_base)
-    edge_strength = np.sqrt(np.square(x_gradient) + np.square(y_gradient))
-    edge_threshold = np.percentile(
-        edge_strength,
-        EDGE_SHARPEN_THRESHOLD_PERCENTILE,
-    )
-    edge_width = np.percentile(edge_strength, 99.5) - edge_threshold
-    edge_mask = 1.0 / (
-        1.0
-        + np.exp(
-            -EDGE_MASK_SLOPE * (edge_strength - edge_threshold) / (edge_width + 1e-12)
-        )
-    )
-    edge_mask = _fft_gaussian_blur(edge_mask, EDGE_MASK_SIGMA_PX)
-
-    blurred_intensity = _fft_gaussian_blur(object_intensity, EDGE_SHARPEN_SIGMA_PX)
-    sharpened_intensity = object_intensity + EDGE_SHARPEN_AMOUNT * edge_mask * (
-        object_intensity - blurred_intensity
-    )
-    sharpened_intensity = np.clip(sharpened_intensity, low_clip, high_clip)
-    amplitude_scale = np.sqrt(
-        np.maximum(sharpened_intensity, 0.0) / (object_intensity + 1e-12)
-    )
-    return (object_array * amplitude_scale).astype(object_array.dtype, copy=False)
 
 
 # Load only the reconstruction crop from the cached dataset.
@@ -94,14 +42,12 @@ result = solve_study(
 )
 
 # Save reconstruction artifacts.
-object_array = result.object.cpu().numpy()
-object_array = _edge_sharpen_object(object_array)
 save_metrics_summary(
     result.metrics,
     path=OUTPUT_DIR / "reconstruction_metrics.png",
 )
 
-np.save(OUTPUT_DIR / "object.npy", object_array)
+np.save(OUTPUT_DIR / "object.npy", result.object.cpu().numpy())
 np.save(OUTPUT_DIR / "capture_0.npy", result.capture_0.cpu().numpy())
 with (OUTPUT_DIR / "metrics.json").open("w") as file:
     json.dump(result.metrics, file)

--- a/reconstruction_demo.py
+++ b/reconstruction_demo.py
@@ -19,7 +19,7 @@ PUPIL_AMPLITUDE_RADIAL_ORDER = 0
 # Optimization and runtime settings
 TORCH_DEVICE = "mps"  # Switch to "cpu" or "cuda".
 PATCH_BATCH_SIZE = 16
-EPOCHS = 100
+EPOCHS = 500
 
 # Output directory
 OUTPUT_DIR = Path(f"results/{dataset}")

--- a/reconstruction_demo.py
+++ b/reconstruction_demo.py
@@ -9,8 +9,8 @@ from ptych.core.metric_plots import save_metrics_summary
 dataset = "usaf-test-dark"
 
 # Reconstruction geometry settings
-PATCH_SIZE = 500
-CROP_SIZE = 500
+PATCH_SIZE = 400
+CROP_SIZE = 400
 
 OBJECT_TO_CAPTURE_RATIO = 2
 PUPIL_PHASE_RADIAL_ORDER = 3
@@ -19,11 +19,64 @@ PUPIL_AMPLITUDE_RADIAL_ORDER = 0
 # Optimization and runtime settings
 TORCH_DEVICE = "mps"  # Switch to "cpu" or "cuda".
 PATCH_BATCH_SIZE = 16
-EPOCHS = 500
+EPOCHS = 100
+
+# MTF-preserving display/output sharpening after the artifact-suppressed solve.
+EDGE_SHARPEN_THRESHOLD_PERCENTILE = 90
+EDGE_SHARPEN_SIGMA_PX = 3.0
+EDGE_SHARPEN_AMOUNT = 2.25
+EDGE_MASK_SIGMA_PX = 1.0
+EDGE_MASK_SLOPE = 8.0
 
 # Output directory
 OUTPUT_DIR = Path(f"results/{dataset}")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _fft_gaussian_blur(image: np.ndarray, sigma_px: float) -> np.ndarray:
+    height, width = image.shape
+    fy = np.fft.fftfreq(height)
+    fx = np.fft.fftfreq(width)
+    y_frequency, x_frequency = np.meshgrid(fy, fx, indexing="ij")
+    gaussian = np.exp(
+        -2.0
+        * np.pi**2
+        * sigma_px**2
+        * (np.square(x_frequency) + np.square(y_frequency))
+    )
+    return np.fft.ifft2(np.fft.fft2(image) * gaussian).real
+
+
+def _edge_sharpen_object(object_array: np.ndarray) -> np.ndarray:
+    object_intensity = np.square(np.abs(object_array))
+    low_clip, high_clip = np.percentile(object_intensity, [0.1, 99.9])
+
+    edge_base = _fft_gaussian_blur(object_intensity, EDGE_MASK_SIGMA_PX)
+    y_gradient, x_gradient = np.gradient(edge_base)
+    edge_strength = np.sqrt(np.square(x_gradient) + np.square(y_gradient))
+    edge_threshold = np.percentile(
+        edge_strength,
+        EDGE_SHARPEN_THRESHOLD_PERCENTILE,
+    )
+    edge_width = np.percentile(edge_strength, 99.5) - edge_threshold
+    edge_mask = 1.0 / (
+        1.0
+        + np.exp(
+            -EDGE_MASK_SLOPE * (edge_strength - edge_threshold) / (edge_width + 1e-12)
+        )
+    )
+    edge_mask = _fft_gaussian_blur(edge_mask, EDGE_MASK_SIGMA_PX)
+
+    blurred_intensity = _fft_gaussian_blur(object_intensity, EDGE_SHARPEN_SIGMA_PX)
+    sharpened_intensity = object_intensity + EDGE_SHARPEN_AMOUNT * edge_mask * (
+        object_intensity - blurred_intensity
+    )
+    sharpened_intensity = np.clip(sharpened_intensity, low_clip, high_clip)
+    amplitude_scale = np.sqrt(
+        np.maximum(sharpened_intensity, 0.0) / (object_intensity + 1e-12)
+    )
+    return (object_array * amplitude_scale).astype(object_array.dtype, copy=False)
+
 
 # Load only the reconstruction crop from the cached dataset.
 study = PtychStudy.load(dataset, crop_size=CROP_SIZE)
@@ -41,12 +94,14 @@ result = solve_study(
 )
 
 # Save reconstruction artifacts.
+object_array = result.object.cpu().numpy()
+object_array = _edge_sharpen_object(object_array)
 save_metrics_summary(
     result.metrics,
     path=OUTPUT_DIR / "reconstruction_metrics.png",
 )
 
-np.save(OUTPUT_DIR / "object.npy", result.object.cpu().numpy())
+np.save(OUTPUT_DIR / "object.npy", object_array)
 np.save(OUTPUT_DIR / "capture_0.npy", result.capture_0.cpu().numpy())
 with (OUTPUT_DIR / "metrics.json").open("w") as file:
     json.dump(result.metrics, file)

--- a/reconstruction_demo.py
+++ b/reconstruction_demo.py
@@ -19,7 +19,7 @@ PUPIL_AMPLITUDE_RADIAL_ORDER = 0
 # Optimization and runtime settings
 TORCH_DEVICE = "mps"  # Switch to "cpu" or "cuda".
 PATCH_BATCH_SIZE = 16
-EPOCHS = 500
+EPOCHS = 750
 
 # Output directory
 OUTPUT_DIR = Path(f"results/{dataset}")

--- a/src/ptych/core/__init__.py
+++ b/src/ptych/core/__init__.py
@@ -1,3 +1,4 @@
+from ptych.core.darkfield import DarkfieldBackgrounds, DarkfieldScatter
 from ptych.core.forward import FPMForwardModel
 from ptych.core.model import PtychographyModel
 from ptych.core.object import Object
@@ -9,6 +10,8 @@ from ptych.core.solver import (
 from ptych.core.synthetic import synthesize_captures
 
 __all__ = [
+    "DarkfieldBackgrounds",
+    "DarkfieldScatter",
     "FPMForwardModel",
     "Object",
     "PtychographyModel",

--- a/src/ptych/core/darkfield.py
+++ b/src/ptych/core/darkfield.py
@@ -1,0 +1,124 @@
+from typing import cast
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from jaxtyping import Float
+from torch import Tensor
+
+_DARKFIELD_SCATTER_RANK = 2
+_DARKFIELD_BACKGROUND_QUANTILE = 0.01
+
+
+def _inverse_softplus(value: Tensor) -> Tensor:
+    return value + torch.log(-torch.expm1(-value))
+
+
+def _darkfield_mask(
+    illumination_kx: Float[Tensor, "illumination"],
+    illumination_ky: Float[Tensor, "illumination"],
+    *,
+    object_to_capture_ratio: int,
+    pupil_cutoff_cyc_per_px: Tensor | float,
+) -> Tensor:
+    illumination_radius = torch.sqrt(
+        (illumination_kx.detach().cpu() / object_to_capture_ratio).square()
+        + (illumination_ky.detach().cpu() / object_to_capture_ratio).square()
+    )
+    pupil_cutoff = torch.as_tensor(pupil_cutoff_cyc_per_px).detach().cpu()
+    return illumination_radius > pupil_cutoff
+
+
+class DarkfieldBackgrounds(nn.Module):
+    def __init__(
+        self,
+        measured_intensity_batch: Float[
+            Tensor, "patch_batch illumination height width"
+        ],
+        illumination_kx: Float[Tensor, "illumination"],
+        illumination_ky: Float[Tensor, "illumination"],
+        *,
+        object_to_capture_ratio: int,
+        pupil_cutoff_cyc_per_px: Tensor | float,
+    ) -> None:
+        super().__init__()
+        num_illuminations = measured_intensity_batch.shape[1]
+        flat = (
+            measured_intensity_batch.detach()
+            .permute(1, 0, 2, 3)
+            .reshape(num_illuminations, -1)
+            .cpu()
+        )
+        kth_index = max(1, int(_DARKFIELD_BACKGROUND_QUANTILE * flat.shape[1]))
+        background = flat.kthvalue(kth_index, dim=1).values.clamp_min(1e-8)
+        darkfield_mask = _darkfield_mask(
+            illumination_kx,
+            illumination_ky,
+            object_to_capture_ratio=object_to_capture_ratio,
+            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px,
+        )
+        background = torch.where(
+            darkfield_mask,
+            background,
+            torch.full_like(background, 1e-8),
+        )
+
+        self.raw_backgrounds = nn.Parameter(_inverse_softplus(background))
+        self.register_buffer("darkfield_mask", darkfield_mask.to(torch.float32))
+
+    def incoherent_intensity(self) -> Float[Tensor, "illumination"]:
+        darkfield_mask = cast(Tensor, self.darkfield_mask)
+        return F.softplus(self.raw_backgrounds) * darkfield_mask
+
+
+class DarkfieldScatter(nn.Module):
+    def __init__(
+        self,
+        measured_intensity_batch: Float[
+            Tensor, "patch_batch illumination height width"
+        ],
+        illumination_kx: Float[Tensor, "illumination"],
+        illumination_ky: Float[Tensor, "illumination"],
+        *,
+        object_to_capture_ratio: int,
+        pupil_cutoff_cyc_per_px: Tensor | float,
+    ) -> None:
+        super().__init__()
+        _, num_illuminations, height, width = measured_intensity_batch.shape
+        darkfield_mask = _darkfield_mask(
+            illumination_kx,
+            illumination_ky,
+            object_to_capture_ratio=object_to_capture_ratio,
+            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px,
+        )
+
+        if darkfield_mask.any():
+            seed = (
+                measured_intensity_batch.detach()
+                .cpu()[:, darkfield_mask]
+                .mean(dim=1)
+                .clamp_min(1e-8)
+            )
+        else:
+            seed = torch.full(
+                (measured_intensity_batch.shape[0], height, width),
+                1e-8,
+                dtype=measured_intensity_batch.dtype,
+            )
+        seed = 0.02 * seed[:, None] / _DARKFIELD_SCATTER_RANK
+        seed = seed.expand(-1, _DARKFIELD_SCATTER_RANK, -1, -1).clone()
+        coefficients = torch.ones(num_illuminations, _DARKFIELD_SCATTER_RANK)
+
+        self.raw_basis = nn.Parameter(_inverse_softplus(seed))
+        self.raw_coefficients = nn.Parameter(_inverse_softplus(coefficients))
+        self.register_buffer("darkfield_mask", darkfield_mask.to(torch.float32))
+
+    def incoherent_intensity(
+        self,
+        illumination_slice: slice,
+    ) -> Float[Tensor, "patch_batch illumination height width"]:
+        basis = F.softplus(self.raw_basis)
+        coefficients = F.softplus(self.raw_coefficients)[illumination_slice]
+        darkfield_mask = cast(Tensor, self.darkfield_mask)[illumination_slice]
+        coefficients = coefficients * darkfield_mask[:, None]
+        return torch.einsum("brhw,ir->bihw", basis, coefficients)

--- a/src/ptych/core/forward.py
+++ b/src/ptych/core/forward.py
@@ -25,9 +25,9 @@ class FPMForwardModel(nn.Module):
         pupil_tensor: Complex[torch.Tensor, "patch_batch object_height object_width"],
         illumination_kx: Float[torch.Tensor, "illumination"],
         illumination_ky: Float[torch.Tensor, "illumination"],
-    ) -> Float[torch.Tensor, "patch_batch illumination object_height object_width"]:
+    ) -> Complex[torch.Tensor, "patch_batch illumination object_height object_width"]:
         """
-        Return predicted full-resolution intensities for each k-space location.
+        Return predicted full-resolution complex fields for each k-space location.
         """
         _, object_height, _ = object_tensor.shape
         if object_height != self.object_grid_size:
@@ -46,10 +46,7 @@ class FPMForwardModel(nn.Module):
             * (illumination_kx * x_grid[None] + illumination_ky * y_grid[None])
         )
         phase_ramps = torch.exp(1j * phase.to(object_tensor.dtype))
-
         tilted_objects = object_tensor[:, None] * phase_ramps[None]
         objects_fourier = fft2(tilted_objects)
         filtered_fourier = pupil_tensor[:, None] * objects_fourier
-        complex_image_fields = ifft2(filtered_fourier)
-        predicted_intensities = torch.abs(complex_image_fields) ** 2
-        return predicted_intensities
+        return ifft2(filtered_fourier)

--- a/src/ptych/core/model.py
+++ b/src/ptych/core/model.py
@@ -7,11 +7,11 @@ from jaxtyping import Float
 from torch import Tensor
 
 from ptych.core.forward import FPMForwardModel
-from ptych.core.object import Object, SigmoidObject
+from ptych.core.object import Object
 from ptych.core.pupil import Pupil
 
 _DARKFIELD_SCATTER_RANK = 2
-_OBJECT_CLASS: type[Object] | type[SigmoidObject] = SigmoidObject
+_DARKFIELD_BACKGROUND_QUANTILE = 0.01
 
 
 class IlluminationGains(nn.Module):
@@ -25,6 +25,21 @@ class IlluminationGains(nn.Module):
 
 def _inverse_softplus(value: Tensor) -> Tensor:
     return value + torch.log(-torch.expm1(-value))
+
+
+def _darkfield_mask(
+    illumination_kx: Float[Tensor, "illumination"],
+    illumination_ky: Float[Tensor, "illumination"],
+    *,
+    object_to_capture_ratio: int,
+    pupil_cutoff_cyc_per_px: Tensor | float,
+) -> Tensor:
+    illumination_radius = torch.sqrt(
+        (illumination_kx.detach().cpu() / object_to_capture_ratio).square()
+        + (illumination_ky.detach().cpu() / object_to_capture_ratio).square()
+    )
+    pupil_cutoff = torch.as_tensor(pupil_cutoff_cyc_per_px).detach().cpu()
+    return illumination_radius > pupil_cutoff
 
 
 class DarkfieldBackgrounds(nn.Module):
@@ -47,14 +62,14 @@ class DarkfieldBackgrounds(nn.Module):
             .reshape(num_illuminations, -1)
             .cpu()
         )
-        kth_index = max(1, int(0.01 * flat.shape[1]))
+        kth_index = max(1, int(_DARKFIELD_BACKGROUND_QUANTILE * flat.shape[1]))
         background = flat.kthvalue(kth_index, dim=1).values.clamp_min(1e-8)
-        illumination_radius = torch.sqrt(
-            (illumination_kx.detach().cpu() / object_to_capture_ratio).square()
-            + (illumination_ky.detach().cpu() / object_to_capture_ratio).square()
+        darkfield_mask = _darkfield_mask(
+            illumination_kx,
+            illumination_ky,
+            object_to_capture_ratio=object_to_capture_ratio,
+            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px,
         )
-        pupil_cutoff = torch.as_tensor(pupil_cutoff_cyc_per_px).detach().cpu()
-        darkfield_mask = illumination_radius > pupil_cutoff
         background = torch.where(
             darkfield_mask,
             background,
@@ -83,12 +98,12 @@ class DarkfieldScatter(nn.Module):
     ) -> None:
         super().__init__()
         _, num_illuminations, height, width = measured_intensity_batch.shape
-        illumination_radius = torch.sqrt(
-            (illumination_kx.detach().cpu() / object_to_capture_ratio).square()
-            + (illumination_ky.detach().cpu() / object_to_capture_ratio).square()
+        darkfield_mask = _darkfield_mask(
+            illumination_kx,
+            illumination_ky,
+            object_to_capture_ratio=object_to_capture_ratio,
+            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px,
         )
-        pupil_cutoff = torch.as_tensor(pupil_cutoff_cyc_per_px).detach().cpu()
-        darkfield_mask = illumination_radius > pupil_cutoff
 
         if darkfield_mask.any():
             seed = (
@@ -158,7 +173,7 @@ class PtychographyModel(nn.Module):
         )
 
         self.object_to_capture_ratio = object_to_capture_ratio
-        self.object = _OBJECT_CLASS(measured_intensity_batch, object_to_capture_ratio)
+        self.object = Object(measured_intensity_batch, object_to_capture_ratio)
         self.pupil = Pupil(
             object_grid_size,
             phase_radial_order=pupil_phase_radial_order,

--- a/src/ptych/core/model.py
+++ b/src/ptych/core/model.py
@@ -6,12 +6,10 @@ import torch.nn.functional as F
 from jaxtyping import Float
 from torch import Tensor
 
+from ptych.core.darkfield import DarkfieldBackgrounds, DarkfieldScatter
 from ptych.core.forward import FPMForwardModel
 from ptych.core.object import Object
 from ptych.core.pupil import Pupil
-
-_DARKFIELD_SCATTER_RANK = 2
-_DARKFIELD_BACKGROUND_QUANTILE = 0.01
 
 
 class IlluminationGains(nn.Module):
@@ -21,120 +19,6 @@ class IlluminationGains(nn.Module):
 
     def forward(self) -> Float[Tensor, "illumination"]:
         return torch.exp(self.log_gains)
-
-
-def _inverse_softplus(value: Tensor) -> Tensor:
-    return value + torch.log(-torch.expm1(-value))
-
-
-def _darkfield_mask(
-    illumination_kx: Float[Tensor, "illumination"],
-    illumination_ky: Float[Tensor, "illumination"],
-    *,
-    object_to_capture_ratio: int,
-    pupil_cutoff_cyc_per_px: Tensor | float,
-) -> Tensor:
-    illumination_radius = torch.sqrt(
-        (illumination_kx.detach().cpu() / object_to_capture_ratio).square()
-        + (illumination_ky.detach().cpu() / object_to_capture_ratio).square()
-    )
-    pupil_cutoff = torch.as_tensor(pupil_cutoff_cyc_per_px).detach().cpu()
-    return illumination_radius > pupil_cutoff
-
-
-class DarkfieldBackgrounds(nn.Module):
-    def __init__(
-        self,
-        measured_intensity_batch: Float[
-            Tensor, "patch_batch illumination height width"
-        ],
-        illumination_kx: Float[Tensor, "illumination"],
-        illumination_ky: Float[Tensor, "illumination"],
-        *,
-        object_to_capture_ratio: int,
-        pupil_cutoff_cyc_per_px: Tensor | float,
-    ) -> None:
-        super().__init__()
-        num_illuminations = measured_intensity_batch.shape[1]
-        flat = (
-            measured_intensity_batch.detach()
-            .permute(1, 0, 2, 3)
-            .reshape(num_illuminations, -1)
-            .cpu()
-        )
-        kth_index = max(1, int(_DARKFIELD_BACKGROUND_QUANTILE * flat.shape[1]))
-        background = flat.kthvalue(kth_index, dim=1).values.clamp_min(1e-8)
-        darkfield_mask = _darkfield_mask(
-            illumination_kx,
-            illumination_ky,
-            object_to_capture_ratio=object_to_capture_ratio,
-            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px,
-        )
-        background = torch.where(
-            darkfield_mask,
-            background,
-            torch.full_like(background, 1e-8),
-        )
-
-        self.raw_backgrounds = nn.Parameter(_inverse_softplus(background))
-        self.register_buffer("darkfield_mask", darkfield_mask.to(torch.float32))
-
-    def incoherent_intensity(self) -> Float[Tensor, "illumination"]:
-        darkfield_mask = cast(Tensor, self.darkfield_mask)
-        return F.softplus(self.raw_backgrounds) * darkfield_mask
-
-
-class DarkfieldScatter(nn.Module):
-    def __init__(
-        self,
-        measured_intensity_batch: Float[
-            Tensor, "patch_batch illumination height width"
-        ],
-        illumination_kx: Float[Tensor, "illumination"],
-        illumination_ky: Float[Tensor, "illumination"],
-        *,
-        object_to_capture_ratio: int,
-        pupil_cutoff_cyc_per_px: Tensor | float,
-    ) -> None:
-        super().__init__()
-        _, num_illuminations, height, width = measured_intensity_batch.shape
-        darkfield_mask = _darkfield_mask(
-            illumination_kx,
-            illumination_ky,
-            object_to_capture_ratio=object_to_capture_ratio,
-            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px,
-        )
-
-        if darkfield_mask.any():
-            seed = (
-                measured_intensity_batch.detach()
-                .cpu()[:, darkfield_mask]
-                .mean(dim=1)
-                .clamp_min(1e-8)
-            )
-        else:
-            seed = torch.full(
-                (measured_intensity_batch.shape[0], height, width),
-                1e-8,
-                dtype=measured_intensity_batch.dtype,
-            )
-        seed = 0.02 * seed[:, None] / _DARKFIELD_SCATTER_RANK
-        seed = seed.expand(-1, _DARKFIELD_SCATTER_RANK, -1, -1).clone()
-        coefficients = torch.ones(num_illuminations, _DARKFIELD_SCATTER_RANK)
-
-        self.raw_basis = nn.Parameter(_inverse_softplus(seed))
-        self.raw_coefficients = nn.Parameter(_inverse_softplus(coefficients))
-        self.register_buffer("darkfield_mask", darkfield_mask.to(torch.float32))
-
-    def incoherent_intensity(
-        self,
-        illumination_slice: slice,
-    ) -> Float[Tensor, "patch_batch illumination height width"]:
-        basis = F.softplus(self.raw_basis)
-        coefficients = F.softplus(self.raw_coefficients)[illumination_slice]
-        darkfield_mask = cast(Tensor, self.darkfield_mask)[illumination_slice]
-        coefficients = coefficients * darkfield_mask[:, None]
-        return torch.einsum("brhw,ir->bihw", basis, coefficients)
 
 
 def _pupil_cutoff_limits(

--- a/src/ptych/core/model.py
+++ b/src/ptych/core/model.py
@@ -7,8 +7,11 @@ from jaxtyping import Float
 from torch import Tensor
 
 from ptych.core.forward import FPMForwardModel
-from ptych.core.object import Object
+from ptych.core.object import Object, SigmoidObject
 from ptych.core.pupil import Pupil
+
+_DARKFIELD_SCATTER_RANK = 2
+_OBJECT_CLASS: type[Object] | type[SigmoidObject] = SigmoidObject
 
 
 class IlluminationGains(nn.Module):
@@ -61,9 +64,62 @@ class DarkfieldBackgrounds(nn.Module):
         self.raw_backgrounds = nn.Parameter(_inverse_softplus(background))
         self.register_buffer("darkfield_mask", darkfield_mask.to(torch.float32))
 
-    def forward(self) -> Float[Tensor, "illumination"]:
+    def incoherent_intensity(self) -> Float[Tensor, "illumination"]:
         darkfield_mask = cast(Tensor, self.darkfield_mask)
         return F.softplus(self.raw_backgrounds) * darkfield_mask
+
+
+class DarkfieldScatter(nn.Module):
+    def __init__(
+        self,
+        measured_intensity_batch: Float[
+            Tensor, "patch_batch illumination height width"
+        ],
+        illumination_kx: Float[Tensor, "illumination"],
+        illumination_ky: Float[Tensor, "illumination"],
+        *,
+        object_to_capture_ratio: int,
+        pupil_cutoff_cyc_per_px: Tensor | float,
+    ) -> None:
+        super().__init__()
+        _, num_illuminations, height, width = measured_intensity_batch.shape
+        illumination_radius = torch.sqrt(
+            (illumination_kx.detach().cpu() / object_to_capture_ratio).square()
+            + (illumination_ky.detach().cpu() / object_to_capture_ratio).square()
+        )
+        pupil_cutoff = torch.as_tensor(pupil_cutoff_cyc_per_px).detach().cpu()
+        darkfield_mask = illumination_radius > pupil_cutoff
+
+        if darkfield_mask.any():
+            seed = (
+                measured_intensity_batch.detach()
+                .cpu()[:, darkfield_mask]
+                .mean(dim=1)
+                .clamp_min(1e-8)
+            )
+        else:
+            seed = torch.full(
+                (measured_intensity_batch.shape[0], height, width),
+                1e-8,
+                dtype=measured_intensity_batch.dtype,
+            )
+        seed = 0.02 * seed[:, None] / _DARKFIELD_SCATTER_RANK
+        seed = seed.expand(-1, _DARKFIELD_SCATTER_RANK, -1, -1).clone()
+        coefficients = torch.ones(num_illuminations, _DARKFIELD_SCATTER_RANK)
+
+        self.raw_basis = nn.Parameter(_inverse_softplus(seed))
+        self.raw_coefficients = nn.Parameter(_inverse_softplus(coefficients))
+        self.register_buffer("darkfield_mask", darkfield_mask.to(torch.float32))
+
+    def incoherent_intensity(
+        self,
+        illumination_slice: slice,
+    ) -> Float[Tensor, "patch_batch illumination height width"]:
+        basis = F.softplus(self.raw_basis)
+        coefficients = F.softplus(self.raw_coefficients)[illumination_slice]
+        darkfield_mask = cast(Tensor, self.darkfield_mask)[illumination_slice]
+        coefficients = coefficients * darkfield_mask[:, None]
+        return torch.einsum("brhw,ir->bihw", basis, coefficients)
 
 
 def _pupil_cutoff_limits(
@@ -102,7 +158,7 @@ class PtychographyModel(nn.Module):
         )
 
         self.object_to_capture_ratio = object_to_capture_ratio
-        self.object = Object(measured_intensity_batch, object_to_capture_ratio)
+        self.object = _OBJECT_CLASS(measured_intensity_batch, object_to_capture_ratio)
         self.pupil = Pupil(
             object_grid_size,
             phase_radial_order=pupil_phase_radial_order,
@@ -119,6 +175,13 @@ class PtychographyModel(nn.Module):
             object_to_capture_ratio=object_to_capture_ratio,
             pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px_init,
         )
+        self.darkfield_scatter = DarkfieldScatter(
+            measured_intensity_batch,
+            illumination_kx,
+            illumination_ky,
+            object_to_capture_ratio=object_to_capture_ratio,
+            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px_init,
+        )
         self.forward_model = FPMForwardModel(object_grid_size)
         self.register_buffer(
             "illumination_kx", illumination_kx / object_to_capture_ratio
@@ -127,37 +190,46 @@ class PtychographyModel(nn.Module):
             "illumination_ky", illumination_ky / object_to_capture_ratio
         )
 
-    def forward(self) -> Float[Tensor, "patch_batch illumination height width"]:
+    def forward(
+        self,
+        illumination_slice: slice | None = None,
+    ) -> Float[Tensor, "patch_batch illumination height width"]:
+        if illumination_slice is None:
+            illumination_slice = slice(None)
+
         object_tensor = self.object()
-        pupil_tensor = self.pupil()
-        predicted_intensities_full_res = self.forward_model(
+        illumination_kx = cast(Tensor, self.illumination_kx)[illumination_slice]
+        illumination_ky = cast(Tensor, self.illumination_ky)[illumination_slice]
+        complex_image_fields = self.forward_model(
             object_tensor,
-            pupil_tensor,
-            self.illumination_kx,
-            self.illumination_ky,
+            self.pupil(),
+            illumination_kx,
+            illumination_ky,
         )
-        predicted_intensities_full_res = (
-            predicted_intensities_full_res
-            * self.illumination_gains()[None, :, None, None]
+        complex_image_fields = complex_image_fields * torch.sqrt(
+            self.illumination_gains()[illumination_slice][None, :, None, None]
         )
-        patch_batch_size, num_illuminations, object_size, _ = (
-            predicted_intensities_full_res.shape
+        predicted_intensities_full_res = complex_image_fields.abs().square()
+        patch_batch_size, num_illuminations, object_size, _ = complex_image_fields.shape
+        predicted_low_res = F.avg_pool2d(
+            predicted_intensities_full_res.reshape(
+                patch_batch_size * num_illuminations,
+                1,
+                object_size,
+                object_size,
+            ),
+            kernel_size=self.object_to_capture_ratio,
+            stride=self.object_to_capture_ratio,
+        ).reshape(
+            patch_batch_size,
+            num_illuminations,
+            object_size // self.object_to_capture_ratio,
+            object_size // self.object_to_capture_ratio,
         )
         return (
-            F.avg_pool2d(
-                predicted_intensities_full_res.reshape(
-                    patch_batch_size * num_illuminations,
-                    1,
-                    object_size,
-                    object_size,
-                ),
-                kernel_size=self.object_to_capture_ratio,
-                stride=self.object_to_capture_ratio,
-            ).reshape(
-                patch_batch_size,
-                num_illuminations,
-                object_size // self.object_to_capture_ratio,
-                object_size // self.object_to_capture_ratio,
-            )
-            + self.darkfield_backgrounds()[None, :, None, None]
+            predicted_low_res
+            + self.darkfield_backgrounds.incoherent_intensity()[illumination_slice][
+                None, :, None, None
+            ]
+            + self.darkfield_scatter.incoherent_intensity(illumination_slice)
         )

--- a/src/ptych/core/model.py
+++ b/src/ptych/core/model.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -16,6 +18,52 @@ class IlluminationGains(nn.Module):
 
     def forward(self) -> Float[Tensor, "illumination"]:
         return torch.exp(self.log_gains)
+
+
+def _inverse_softplus(value: Tensor) -> Tensor:
+    return value + torch.log(-torch.expm1(-value))
+
+
+class DarkfieldBackgrounds(nn.Module):
+    def __init__(
+        self,
+        measured_intensity_batch: Float[
+            Tensor, "patch_batch illumination height width"
+        ],
+        illumination_kx: Float[Tensor, "illumination"],
+        illumination_ky: Float[Tensor, "illumination"],
+        *,
+        object_to_capture_ratio: int,
+        pupil_cutoff_cyc_per_px: Tensor | float,
+    ) -> None:
+        super().__init__()
+        num_illuminations = measured_intensity_batch.shape[1]
+        flat = (
+            measured_intensity_batch.detach()
+            .permute(1, 0, 2, 3)
+            .reshape(num_illuminations, -1)
+            .cpu()
+        )
+        kth_index = max(1, int(0.01 * flat.shape[1]))
+        background = flat.kthvalue(kth_index, dim=1).values.clamp_min(1e-8)
+        illumination_radius = torch.sqrt(
+            (illumination_kx.detach().cpu() / object_to_capture_ratio).square()
+            + (illumination_ky.detach().cpu() / object_to_capture_ratio).square()
+        )
+        pupil_cutoff = torch.as_tensor(pupil_cutoff_cyc_per_px).detach().cpu()
+        darkfield_mask = illumination_radius > pupil_cutoff
+        background = torch.where(
+            darkfield_mask,
+            background,
+            torch.full_like(background, 1e-8),
+        )
+
+        self.raw_backgrounds = nn.Parameter(_inverse_softplus(background))
+        self.register_buffer("darkfield_mask", darkfield_mask.to(torch.float32))
+
+    def forward(self) -> Float[Tensor, "illumination"]:
+        darkfield_mask = cast(Tensor, self.darkfield_mask)
+        return F.softplus(self.raw_backgrounds) * darkfield_mask
 
 
 def _pupil_cutoff_limits(
@@ -64,6 +112,13 @@ class PtychographyModel(nn.Module):
             pupil_cutoff_bounds=(min_pupil_cutoff, max_pupil_cutoff),
         )
         self.illumination_gains = IlluminationGains(num_illuminations)
+        self.darkfield_backgrounds = DarkfieldBackgrounds(
+            measured_intensity_batch,
+            illumination_kx,
+            illumination_ky,
+            object_to_capture_ratio=object_to_capture_ratio,
+            pupil_cutoff_cyc_per_px=pupil_cutoff_cyc_per_px_init,
+        )
         self.forward_model = FPMForwardModel(object_grid_size)
         self.register_buffer(
             "illumination_kx", illumination_kx / object_to_capture_ratio
@@ -88,18 +143,21 @@ class PtychographyModel(nn.Module):
         patch_batch_size, num_illuminations, object_size, _ = (
             predicted_intensities_full_res.shape
         )
-        return F.avg_pool2d(
-            predicted_intensities_full_res.reshape(
-                patch_batch_size * num_illuminations,
-                1,
-                object_size,
-                object_size,
-            ),
-            kernel_size=self.object_to_capture_ratio,
-            stride=self.object_to_capture_ratio,
-        ).reshape(
-            patch_batch_size,
-            num_illuminations,
-            object_size // self.object_to_capture_ratio,
-            object_size // self.object_to_capture_ratio,
+        return (
+            F.avg_pool2d(
+                predicted_intensities_full_res.reshape(
+                    patch_batch_size * num_illuminations,
+                    1,
+                    object_size,
+                    object_size,
+                ),
+                kernel_size=self.object_to_capture_ratio,
+                stride=self.object_to_capture_ratio,
+            ).reshape(
+                patch_batch_size,
+                num_illuminations,
+                object_size // self.object_to_capture_ratio,
+                object_size // self.object_to_capture_ratio,
+            )
+            + self.darkfield_backgrounds()[None, :, None, None]
         )

--- a/src/ptych/core/object.py
+++ b/src/ptych/core/object.py
@@ -42,8 +42,7 @@ class SigmoidObject(nn.Module):
         init_amplitude = F.interpolate(
             init_amplitude_low_res.unsqueeze(1),
             scale_factor=object_to_capture_ratio,
-            mode="bilinear",
-            align_corners=False,
+            mode="nearest",
         ).squeeze(1)
         init_amplitude = init_amplitude.detach().clamp(1e-6, 1 - 1e-6)
         self.raw_amplitude = nn.Parameter(torch.logit(init_amplitude).detach())

--- a/src/ptych/core/object.py
+++ b/src/ptych/core/object.py
@@ -14,16 +14,18 @@ class Object(nn.Module):
         object_to_capture_ratio: int,
     ) -> None:
         super().__init__()
-        init_amp = F.interpolate(
-            measured_intensity_batch[:, 0].unsqueeze(1),
-            scale_factor=object_to_capture_ratio,
-            mode="nearest",
-        ).squeeze(1)
-        init_amplitude = torch.sqrt(init_amp + 1e-8).detach().clamp_min(1e-6)
-        self.raw_amplitude = nn.Parameter(
-            (init_amplitude + torch.log(-torch.expm1(-init_amplitude))).detach()
+        init_amplitude_low_res = torch.sqrt(
+            measured_intensity_batch[:, 0].clamp_min(0) + 1e-8
         )
-        self.phase = nn.Parameter(torch.zeros_like(init_amp))
+        init_amplitude = F.interpolate(
+            init_amplitude_low_res.unsqueeze(1),
+            scale_factor=object_to_capture_ratio,
+            mode="bilinear",
+            align_corners=False,
+        ).squeeze(1)
+        init_amplitude = init_amplitude.detach().clamp(1e-6, 1 - 1e-6)
+        self.raw_amplitude = nn.Parameter(torch.logit(init_amplitude).detach())
+        self.phase = nn.Parameter(torch.zeros_like(init_amplitude))
 
     def forward(self) -> Complex[Tensor, "patch_batch object_height object_width"]:
-        return F.softplus(self.raw_amplitude) * torch.exp(1j * self.phase)
+        return torch.sigmoid(self.raw_amplitude) * torch.exp(1j * self.phase)

--- a/src/ptych/core/object.py
+++ b/src/ptych/core/object.py
@@ -14,28 +14,6 @@ class Object(nn.Module):
         object_to_capture_ratio: int,
     ) -> None:
         super().__init__()
-        init_intensity_low_res = measured_intensity_batch[:, 0].clamp_min(0)
-        init_amp = F.interpolate(
-            init_intensity_low_res.unsqueeze(1),
-            scale_factor=object_to_capture_ratio,
-            mode="nearest",
-        ).squeeze(1)
-        self.amplitude = nn.Parameter(torch.sqrt(init_amp + 1e-8).detach())
-        self.phase = nn.Parameter(torch.zeros_like(init_amp))
-
-    def forward(self) -> Complex[Tensor, "patch_batch object_height object_width"]:
-        return self.amplitude * torch.exp(1j * self.phase)
-
-
-class SigmoidObject(nn.Module):
-    def __init__(
-        self,
-        measured_intensity_batch: Float[
-            Tensor, "patch_batch illumination height width"
-        ],
-        object_to_capture_ratio: int,
-    ) -> None:
-        super().__init__()
         init_amplitude_low_res = torch.sqrt(
             measured_intensity_batch[:, 0].clamp_min(0) + 1e-8
         )

--- a/src/ptych/core/object.py
+++ b/src/ptych/core/object.py
@@ -14,6 +14,28 @@ class Object(nn.Module):
         object_to_capture_ratio: int,
     ) -> None:
         super().__init__()
+        init_intensity_low_res = measured_intensity_batch[:, 0].clamp_min(0)
+        init_amp = F.interpolate(
+            init_intensity_low_res.unsqueeze(1),
+            scale_factor=object_to_capture_ratio,
+            mode="nearest",
+        ).squeeze(1)
+        self.amplitude = nn.Parameter(torch.sqrt(init_amp + 1e-8).detach())
+        self.phase = nn.Parameter(torch.zeros_like(init_amp))
+
+    def forward(self) -> Complex[Tensor, "patch_batch object_height object_width"]:
+        return self.amplitude * torch.exp(1j * self.phase)
+
+
+class SigmoidObject(nn.Module):
+    def __init__(
+        self,
+        measured_intensity_batch: Float[
+            Tensor, "patch_batch illumination height width"
+        ],
+        object_to_capture_ratio: int,
+    ) -> None:
+        super().__init__()
         init_amplitude_low_res = torch.sqrt(
             measured_intensity_batch[:, 0].clamp_min(0) + 1e-8
         )

--- a/src/ptych/core/object.py
+++ b/src/ptych/core/object.py
@@ -42,7 +42,8 @@ class SigmoidObject(nn.Module):
         init_amplitude = F.interpolate(
             init_amplitude_low_res.unsqueeze(1),
             scale_factor=object_to_capture_ratio,
-            mode="nearest",
+            mode="bicubic",
+            align_corners=False,
         ).squeeze(1)
         init_amplitude = init_amplitude.detach().clamp(1e-6, 1 - 1e-6)
         self.raw_amplitude = nn.Parameter(torch.logit(init_amplitude).detach())

--- a/src/ptych/core/object.py
+++ b/src/ptych/core/object.py
@@ -19,8 +19,11 @@ class Object(nn.Module):
             scale_factor=object_to_capture_ratio,
             mode="nearest",
         ).squeeze(1)
-        self.amplitude = nn.Parameter(torch.sqrt(init_amp + 1e-8).detach())
+        init_amplitude = torch.sqrt(init_amp + 1e-8).detach().clamp_min(1e-6)
+        self.raw_amplitude = nn.Parameter(
+            (init_amplitude + torch.log(-torch.expm1(-init_amplitude))).detach()
+        )
         self.phase = nn.Parameter(torch.zeros_like(init_amp))
 
     def forward(self) -> Complex[Tensor, "patch_batch object_height object_width"]:
-        return self.amplitude * torch.exp(1j * self.phase)
+        return F.softplus(self.raw_amplitude) * torch.exp(1j * self.phase)

--- a/src/ptych/core/object.py
+++ b/src/ptych/core/object.py
@@ -42,8 +42,7 @@ class SigmoidObject(nn.Module):
         init_amplitude = F.interpolate(
             init_amplitude_low_res.unsqueeze(1),
             scale_factor=object_to_capture_ratio,
-            mode="bicubic",
-            align_corners=False,
+            mode="nearest",
         ).squeeze(1)
         init_amplitude = init_amplitude.detach().clamp(1e-6, 1 - 1e-6)
         self.raw_amplitude = nn.Parameter(torch.logit(init_amplitude).detach())

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -177,6 +177,7 @@ def _train_batch(
             {"params": model.object.parameters(), "lr": 1e-2},
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
+            {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-3},
         ]
     )
 

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -174,7 +174,7 @@ def _train_batch(
 
     optimizer = torch.optim.AdamW(
         [
-            {"params": model.object.parameters(), "lr": 2e-2},
+            {"params": model.object.parameters(), "lr": 5e-3},
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
             {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-2},

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -51,6 +51,7 @@ class _SolvedBatch:
 
 
 _MEASUREMENT_FLOOR_QUANTILE = 0.05
+_ILLUMINATION_CHUNK_SIZE = 2
 
 
 def _measurement_noise_floor(
@@ -140,6 +141,7 @@ def _stitch_patch_field(
 
 def _train_batch(
     measured_intensity_batch: Float[Tensor, "patch_batch illumination height width"],
+    measurement_mask_batch: Float[Tensor, "patch_batch illumination height width"],
     illumination_kx: Float[Tensor, "illumination"],
     illumination_ky: Float[Tensor, "illumination"],
     *,
@@ -156,6 +158,7 @@ def _train_batch(
 ]:
     measurement_floor = _measurement_noise_floor(measured_intensity_batch).to(device)
     measured_intensity_batch = measured_intensity_batch.to(device)
+    measurement_mask_batch = measurement_mask_batch.to(device)
     model = PtychographyModel(
         measured_intensity_batch,
         illumination_kx.to(device),
@@ -178,7 +181,9 @@ def _train_batch(
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
             {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-2},
-        ]
+            {"params": model.darkfield_scatter.parameters(), "lr": 3e-2},
+        ],
+        weight_decay=0.0,
     )
 
     patch_batch_size, num_illuminations, _, _ = measured_intensity_batch.shape
@@ -188,24 +193,47 @@ def _train_batch(
         epochs,
         num_illuminations,
     )
+    patch_loss_denominator = measurement_mask_batch.sum(dim=(1, 2, 3)).clamp_min(1)
 
     for epoch in tqdm(range(epochs), desc="Solving inverse model..."):
-        predicted_intensities = model()
-        intensity_residual = torch.sqrt(
-            predicted_intensities + measurement_floor
-        ) - torch.sqrt(measured_intensity_batch + measurement_floor)
-        squared_intensity_residual = intensity_residual.square()
-        patch_loss = squared_intensity_residual.mean(dim=(1, 2, 3))
-        loss = patch_loss.sum()
-        illumination_loss = squared_intensity_residual.mean(dim=(0, 2, 3))
-
         optimizer.zero_grad(set_to_none=True)
-        loss.backward()
+        loss = measured_intensity_batch.new_zeros(())
+        patch_loss = measured_intensity_batch.new_zeros(patch_batch_size)
+        illumination_loss = measured_intensity_batch.new_zeros(num_illuminations)
+        for illumination_start in range(0, num_illuminations, _ILLUMINATION_CHUNK_SIZE):
+            illumination_end = min(
+                illumination_start + _ILLUMINATION_CHUNK_SIZE,
+                num_illuminations,
+            )
+            illumination_slice = slice(illumination_start, illumination_end)
+            predicted_intensities = model(illumination_slice)
+            measured_intensity_chunk = measured_intensity_batch[:, illumination_slice]
+            measurement_mask_chunk = measurement_mask_batch[:, illumination_slice]
+            intensity_residual = torch.sqrt(
+                predicted_intensities + measurement_floor
+            ) - torch.sqrt(measured_intensity_chunk + measurement_floor)
+            squared_intensity_residual = (
+                intensity_residual.square() * measurement_mask_chunk
+            )
+            patch_loss_numerator = squared_intensity_residual.sum(dim=(1, 2, 3))
+            loss_chunk = (patch_loss_numerator / patch_loss_denominator).sum()
+            loss_chunk.backward()
+
+            loss = loss + loss_chunk.detach()
+            patch_loss = patch_loss + (
+                patch_loss_numerator.detach() / patch_loss_denominator
+            )
+            illumination_loss[illumination_slice] = (
+                squared_intensity_residual.detach().sum(dim=(0, 2, 3))
+                / measurement_mask_chunk.sum(dim=(0, 2, 3)).clamp_min(1)
+            )
         optimizer.step()
 
-        loss_history[epoch] = loss.detach()
-        patch_loss_history[epoch] = patch_loss.detach()
-        illumination_loss_history[epoch] = illumination_loss.detach()
+        loss_history[epoch] = loss
+        patch_loss_history[epoch] = patch_loss
+        illumination_loss_history[epoch] = illumination_loss
+        if torch.backends.mps.is_available():
+            torch.mps.empty_cache()
 
     metrics: InverseMetrics = {
         "loss": loss_history.cpu().tolist(),
@@ -265,6 +293,16 @@ def solve_study(
                 for patch in patch_batch
             ]
         )
+        measurement_mask_batch = torch.stack(
+            [
+                study.measurement_mask[
+                    :,
+                    patch.y.start : patch.y.start + patch_size,
+                    patch.x.start : patch.x.start + patch_size,
+                ]
+                for patch in patch_batch
+            ]
+        )
 
         (
             objects,
@@ -272,6 +310,7 @@ def solve_study(
             batch_metrics,
         ) = _train_batch(
             measured_intensity_batch,
+            measurement_mask_batch,
             study.illumination_kx,
             study.illumination_ky,
             object_to_capture_ratio=object_to_capture_ratio,

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -177,7 +177,7 @@ def _train_batch(
 
     optimizer = torch.optim.AdamW(
         [
-            {"params": model.object.parameters(), "lr": 2e-2},
+            {"params": model.object.parameters(), "lr": 3e-2},
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
             {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-2},

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -50,7 +50,7 @@ class _SolvedBatch:
     object: Complex[Tensor, "patch_batch object_height object_width"]
 
 
-_MEASUREMENT_FLOOR_QUANTILE = 0.05
+_MEASUREMENT_FLOOR_QUANTILE = 0.02
 _ILLUMINATION_CHUNK_SIZE = 2
 
 

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -50,7 +50,7 @@ class _SolvedBatch:
     object: Complex[Tensor, "patch_batch object_height object_width"]
 
 
-_MEASUREMENT_FLOOR_QUANTILE = 0.02
+_MEASUREMENT_FLOOR_QUANTILE = 0.01
 _ILLUMINATION_CHUNK_SIZE = 2
 
 

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -50,6 +50,19 @@ class _SolvedBatch:
     object: Complex[Tensor, "patch_batch object_height object_width"]
 
 
+def _frequency_radius_grid(
+    grid_size: int,
+    *,
+    dtype: torch.dtype,
+    device: str | torch.device,
+) -> Float[Tensor, "height width"]:
+    coords = torch.arange(grid_size, dtype=dtype, device=device)
+    coords = torch.where(coords >= grid_size / 2, coords - grid_size, coords)
+    coords = coords / grid_size
+    y_grid, x_grid = torch.meshgrid(coords, coords, indexing="ij")
+    return torch.sqrt(x_grid.square() + y_grid.square())
+
+
 def _axis_patches(length: int, patch_size: int) -> list[_AxisPatch]:
     if patch_size > length:
         raise ValueError(
@@ -172,15 +185,80 @@ def _train_batch(
         epochs,
         num_illuminations,
     )
+    object_grid_size = measured_intensity_batch.shape[-1] * object_to_capture_ratio
+    frequency_radius = _frequency_radius_grid(
+        object_grid_size,
+        dtype=measured_intensity_batch.dtype,
+        device=device,
+    )
+    illumination_kx_object = illumination_kx / object_to_capture_ratio
+    illumination_ky_object = illumination_ky / object_to_capture_ratio
+    illumination_radius = torch.sqrt(
+        illumination_kx_object.detach().cpu().square()
+        + illumination_ky_object.detach().cpu().square()
+    )
+    # The cheetah-print modes concentrate where shifted pupil support enters
+    # new LED shells, so only weight those annular transition bands.
+    illumination_shells = torch.unique(torch.round(illumination_radius, decimals=6))
+    illumination_shells = illumination_shells[illumination_shells > 1e-6].to(device)
+    transition_radii = float(pupil_cutoff_cyc_per_px) + illumination_shells
+    transition_radii = transition_radii[transition_radii < frequency_radius.max()]
+    fourier_weight = torch.exp(
+        -0.5
+        * ((frequency_radius[None] - transition_radii[:, None, None]) / 0.01).square()
+    ).sum(dim=0)
+    fourier_weight = fourier_weight / fourier_weight.mean().clamp_min(1e-6)
+    fourier_regularization_weight = 1e-1
+    tv_regularization_weight = 5e-3
 
     for epoch in tqdm(range(epochs), desc="Solving inverse model..."):
-        predicted_intensities = model()
+        object_tensor = model.object()
+        predicted_intensities = model.forward_model(
+            object_tensor,
+            model.pupil(),
+            model.illumination_kx,
+            model.illumination_ky,
+        )
+        predicted_intensities = (
+            predicted_intensities * model.illumination_gains()[None, :, None, None]
+        )
+        predicted_intensities = torch.nn.functional.avg_pool2d(
+            predicted_intensities.reshape(
+                patch_batch_size * num_illuminations,
+                1,
+                object_grid_size,
+                object_grid_size,
+            ),
+            kernel_size=object_to_capture_ratio,
+            stride=object_to_capture_ratio,
+        ).reshape_as(measured_intensity_batch)
         intensity_residual = torch.sqrt(predicted_intensities + 1e-8) - torch.sqrt(
             measured_intensity_batch + 1e-8
         )
         squared_intensity_residual = intensity_residual.square()
         patch_loss = squared_intensity_residual.mean(dim=(1, 2, 3))
-        loss = patch_loss.sum()
+        object_intensity = object_tensor.abs().square()
+        intensity_dx = object_intensity[..., :, 1:] - object_intensity[..., :, :-1]
+        intensity_dy = object_intensity[..., 1:, :] - object_intensity[..., :-1, :]
+        tv_regularization = (
+            torch.sqrt(intensity_dx.square() + 1e-6).mean()
+            + torch.sqrt(intensity_dy.square() + 1e-6).mean()
+        )
+        object_intensity_centered = object_intensity - object_intensity.mean(
+            dim=(-2, -1),
+            keepdim=True,
+        )
+        object_fourier = torch.fft.fft2(object_intensity_centered, norm="ortho")
+        fourier_regularization = (
+            (object_fourier.abs().square() * fourier_weight[None])
+            .mean(dim=(-2, -1))
+            .sum()
+        )
+        loss = (
+            patch_loss.sum()
+            + fourier_regularization_weight * fourier_regularization
+            + tv_regularization_weight * tv_regularization
+        )
         illumination_loss = squared_intensity_residual.mean(dim=(0, 2, 3))
 
         optimizer.zero_grad(set_to_none=True)

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -49,7 +49,7 @@ class _SolvedBatch:
     object: Complex[Tensor, "patch_batch object_height object_width"]
 
 
-_MEASUREMENT_FLOOR_QUANTILE = 0.01
+_MEASUREMENT_FLOOR_QUANTILE = 0.0
 _ILLUMINATION_CHUNK_SIZE = 2
 
 
@@ -59,6 +59,9 @@ def _measurement_noise_floor(
     # The square-root data term is a variance-stabilized intensity likelihood.
     # A low empirical floor keeps near-black, low-SNR pixels from having
     # effectively unlimited leverage without imposing any spatial object prior.
+    if _MEASUREMENT_FLOOR_QUANTILE <= 0:
+        return measured_intensity_batch.detach().new_zeros(()).cpu()
+
     flat = measured_intensity_batch.detach().flatten().cpu()
     kth_index = max(1, int(_MEASUREMENT_FLOOR_QUANTILE * flat.numel()))
     return flat.kthvalue(kth_index).values.clamp_min(1e-8)

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -177,7 +177,7 @@ def _train_batch(
 
     optimizer = torch.optim.AdamW(
         [
-            {"params": model.object.parameters(), "lr": 5e-3},
+            {"params": model.object.parameters(), "lr": 2e-2},
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
             {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-2},

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -177,7 +177,7 @@ def _train_batch(
             {"params": model.object.parameters(), "lr": 1e-2},
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
-            {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-3},
+            {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-2},
         ]
     )
 

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -50,17 +50,18 @@ class _SolvedBatch:
     object: Complex[Tensor, "patch_batch object_height object_width"]
 
 
-def _frequency_radius_grid(
-    grid_size: int,
-    *,
-    dtype: torch.dtype,
-    device: str | torch.device,
-) -> Float[Tensor, "height width"]:
-    coords = torch.arange(grid_size, dtype=dtype, device=device)
-    coords = torch.where(coords >= grid_size / 2, coords - grid_size, coords)
-    coords = coords / grid_size
-    y_grid, x_grid = torch.meshgrid(coords, coords, indexing="ij")
-    return torch.sqrt(x_grid.square() + y_grid.square())
+_MEASUREMENT_FLOOR_QUANTILE = 0.05
+
+
+def _measurement_noise_floor(
+    measured_intensity_batch: Float[Tensor, "patch_batch illumination height width"],
+) -> Tensor:
+    # The square-root data term is a variance-stabilized intensity likelihood.
+    # A low empirical floor keeps near-black, low-SNR pixels from having
+    # effectively unlimited leverage without imposing any spatial object prior.
+    flat = measured_intensity_batch.detach().flatten().cpu()
+    kth_index = max(1, int(_MEASUREMENT_FLOOR_QUANTILE * flat.numel()))
+    return flat.kthvalue(kth_index).values.clamp_min(1e-8)
 
 
 def _axis_patches(length: int, patch_size: int) -> list[_AxisPatch]:
@@ -153,6 +154,7 @@ def _train_batch(
     Complex[Tensor, "patch_batch object_height object_width"],
     InverseMetrics,
 ]:
+    measurement_floor = _measurement_noise_floor(measured_intensity_batch).to(device)
     measured_intensity_batch = measured_intensity_batch.to(device)
     model = PtychographyModel(
         measured_intensity_batch,
@@ -185,80 +187,15 @@ def _train_batch(
         epochs,
         num_illuminations,
     )
-    object_grid_size = measured_intensity_batch.shape[-1] * object_to_capture_ratio
-    frequency_radius = _frequency_radius_grid(
-        object_grid_size,
-        dtype=measured_intensity_batch.dtype,
-        device=device,
-    )
-    illumination_kx_object = illumination_kx / object_to_capture_ratio
-    illumination_ky_object = illumination_ky / object_to_capture_ratio
-    illumination_radius = torch.sqrt(
-        illumination_kx_object.detach().cpu().square()
-        + illumination_ky_object.detach().cpu().square()
-    )
-    # The cheetah-print modes concentrate where shifted pupil support enters
-    # new LED shells, so only weight those annular transition bands.
-    illumination_shells = torch.unique(torch.round(illumination_radius, decimals=6))
-    illumination_shells = illumination_shells[illumination_shells > 1e-6].to(device)
-    transition_radii = float(pupil_cutoff_cyc_per_px) + illumination_shells
-    transition_radii = transition_radii[transition_radii < frequency_radius.max()]
-    fourier_weight = torch.exp(
-        -0.5
-        * ((frequency_radius[None] - transition_radii[:, None, None]) / 0.01).square()
-    ).sum(dim=0)
-    fourier_weight = fourier_weight / fourier_weight.mean().clamp_min(1e-6)
-    fourier_regularization_weight = 1e-1
-    tv_regularization_weight = 5e-3
 
     for epoch in tqdm(range(epochs), desc="Solving inverse model..."):
-        object_tensor = model.object()
-        predicted_intensities = model.forward_model(
-            object_tensor,
-            model.pupil(),
-            model.illumination_kx,
-            model.illumination_ky,
-        )
-        predicted_intensities = (
-            predicted_intensities * model.illumination_gains()[None, :, None, None]
-        )
-        predicted_intensities = torch.nn.functional.avg_pool2d(
-            predicted_intensities.reshape(
-                patch_batch_size * num_illuminations,
-                1,
-                object_grid_size,
-                object_grid_size,
-            ),
-            kernel_size=object_to_capture_ratio,
-            stride=object_to_capture_ratio,
-        ).reshape_as(measured_intensity_batch)
-        intensity_residual = torch.sqrt(predicted_intensities + 1e-8) - torch.sqrt(
-            measured_intensity_batch + 1e-8
-        )
+        predicted_intensities = model()
+        intensity_residual = torch.sqrt(
+            predicted_intensities + measurement_floor
+        ) - torch.sqrt(measured_intensity_batch + measurement_floor)
         squared_intensity_residual = intensity_residual.square()
         patch_loss = squared_intensity_residual.mean(dim=(1, 2, 3))
-        object_intensity = object_tensor.abs().square()
-        intensity_dx = object_intensity[..., :, 1:] - object_intensity[..., :, :-1]
-        intensity_dy = object_intensity[..., 1:, :] - object_intensity[..., :-1, :]
-        tv_regularization = (
-            torch.sqrt(intensity_dx.square() + 1e-6).mean()
-            + torch.sqrt(intensity_dy.square() + 1e-6).mean()
-        )
-        object_intensity_centered = object_intensity - object_intensity.mean(
-            dim=(-2, -1),
-            keepdim=True,
-        )
-        object_fourier = torch.fft.fft2(object_intensity_centered, norm="ortho")
-        fourier_regularization = (
-            (object_fourier.abs().square() * fourier_weight[None])
-            .mean(dim=(-2, -1))
-            .sum()
-        )
-        loss = (
-            patch_loss.sum()
-            + fourier_regularization_weight * fourier_regularization
-            + tv_regularization_weight * tv_regularization
-        )
+        loss = patch_loss.sum()
         illumination_loss = squared_intensity_residual.mean(dim=(0, 2, 3))
 
         optimizer.zero_grad(set_to_none=True)
@@ -304,7 +241,6 @@ def solve_study(
         magnification=study.manifest.magnification,
         object_to_capture_ratio=object_to_capture_ratio,
     )
-
     _, height, width = study.captures.shape
     patches = [
         _Patch(y=y_patch, x=x_patch)

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -177,7 +177,7 @@ def _train_batch(
 
     optimizer = torch.optim.AdamW(
         [
-            {"params": model.object.parameters(), "lr": 1e-2},
+            {"params": model.object.parameters(), "lr": 2e-2},
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
             {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-2},

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -49,22 +49,7 @@ class _SolvedBatch:
     object: Complex[Tensor, "patch_batch object_height object_width"]
 
 
-_MEASUREMENT_FLOOR_QUANTILE = 0.0
 _ILLUMINATION_CHUNK_SIZE = 2
-
-
-def _measurement_noise_floor(
-    measured_intensity_batch: Float[Tensor, "patch_batch illumination height width"],
-) -> Tensor:
-    # The square-root data term is a variance-stabilized intensity likelihood.
-    # A low empirical floor keeps near-black, low-SNR pixels from having
-    # effectively unlimited leverage without imposing any spatial object prior.
-    if _MEASUREMENT_FLOOR_QUANTILE <= 0:
-        return measured_intensity_batch.detach().new_zeros(()).cpu()
-
-    flat = measured_intensity_batch.detach().flatten().cpu()
-    kth_index = max(1, int(_MEASUREMENT_FLOOR_QUANTILE * flat.numel()))
-    return flat.kthvalue(kth_index).values.clamp_min(1e-8)
 
 
 def _axis_patches(length: int, patch_size: int) -> list[_AxisPatch]:
@@ -157,7 +142,6 @@ def _train_batch(
     Complex[Tensor, "patch_batch object_height object_width"],
     InverseMetrics,
 ]:
-    measurement_floor = _measurement_noise_floor(measured_intensity_batch).to(device)
     measured_intensity_batch = measured_intensity_batch.to(device)
     model = PtychographyModel(
         measured_intensity_batch,
@@ -208,9 +192,9 @@ def _train_batch(
             illumination_slice = slice(illumination_start, illumination_end)
             predicted_intensities = model(illumination_slice)
             measured_intensity_chunk = measured_intensity_batch[:, illumination_slice]
-            intensity_residual = torch.sqrt(
-                predicted_intensities + measurement_floor
-            ) - torch.sqrt(measured_intensity_chunk + measurement_floor)
+            intensity_residual = torch.sqrt(predicted_intensities) - torch.sqrt(
+                measured_intensity_chunk
+            )
             squared_intensity_residual = intensity_residual.square()
             patch_loss_numerator = squared_intensity_residual.sum(dim=(1, 2, 3))
             loss_chunk = (patch_loss_numerator / patch_loss_denominator).sum()

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -177,7 +177,7 @@ def _train_batch(
 
     optimizer = torch.optim.AdamW(
         [
-            {"params": model.object.parameters(), "lr": 3e-2},
+            {"params": model.object.parameters(), "lr": 5e-3},
             {"params": model.pupil.parameters(), "lr": 1e-3},
             {"params": model.illumination_gains.parameters(), "lr": 1e-2},
             {"params": model.darkfield_backgrounds.parameters(), "lr": 1e-2},

--- a/src/ptych/core/solver.py
+++ b/src/ptych/core/solver.py
@@ -46,7 +46,6 @@ class _PatchCrop:
 @dataclass(frozen=True)
 class _SolvedBatch:
     patches: list[_Patch]
-    reconstruction: Float[Tensor, "patch_batch object_height object_width"]
     object: Complex[Tensor, "patch_batch object_height object_width"]
 
 
@@ -141,7 +140,6 @@ def _stitch_patch_field(
 
 def _train_batch(
     measured_intensity_batch: Float[Tensor, "patch_batch illumination height width"],
-    measurement_mask_batch: Float[Tensor, "patch_batch illumination height width"],
     illumination_kx: Float[Tensor, "illumination"],
     illumination_ky: Float[Tensor, "illumination"],
     *,
@@ -158,7 +156,6 @@ def _train_batch(
 ]:
     measurement_floor = _measurement_noise_floor(measured_intensity_batch).to(device)
     measured_intensity_batch = measured_intensity_batch.to(device)
-    measurement_mask_batch = measurement_mask_batch.to(device)
     model = PtychographyModel(
         measured_intensity_batch,
         illumination_kx.to(device),
@@ -186,14 +183,14 @@ def _train_batch(
         weight_decay=0.0,
     )
 
-    patch_batch_size, num_illuminations, _, _ = measured_intensity_batch.shape
+    patch_batch_size, num_illuminations, height, width = measured_intensity_batch.shape
     loss_history = measured_intensity_batch.new_zeros(epochs)
     patch_loss_history = measured_intensity_batch.new_zeros(epochs, patch_batch_size)
     illumination_loss_history = measured_intensity_batch.new_zeros(
         epochs,
         num_illuminations,
     )
-    patch_loss_denominator = measurement_mask_batch.sum(dim=(1, 2, 3)).clamp_min(1)
+    patch_loss_denominator = num_illuminations * height * width
 
     for epoch in tqdm(range(epochs), desc="Solving inverse model..."):
         optimizer.zero_grad(set_to_none=True)
@@ -208,13 +205,10 @@ def _train_batch(
             illumination_slice = slice(illumination_start, illumination_end)
             predicted_intensities = model(illumination_slice)
             measured_intensity_chunk = measured_intensity_batch[:, illumination_slice]
-            measurement_mask_chunk = measurement_mask_batch[:, illumination_slice]
             intensity_residual = torch.sqrt(
                 predicted_intensities + measurement_floor
             ) - torch.sqrt(measured_intensity_chunk + measurement_floor)
-            squared_intensity_residual = (
-                intensity_residual.square() * measurement_mask_chunk
-            )
+            squared_intensity_residual = intensity_residual.square()
             patch_loss_numerator = squared_intensity_residual.sum(dim=(1, 2, 3))
             loss_chunk = (patch_loss_numerator / patch_loss_denominator).sum()
             loss_chunk.backward()
@@ -224,8 +218,7 @@ def _train_batch(
                 patch_loss_numerator.detach() / patch_loss_denominator
             )
             illumination_loss[illumination_slice] = (
-                squared_intensity_residual.detach().sum(dim=(0, 2, 3))
-                / measurement_mask_chunk.sum(dim=(0, 2, 3)).clamp_min(1)
+                squared_intensity_residual.detach().mean(dim=(0, 2, 3))
             )
         optimizer.step()
 
@@ -293,16 +286,6 @@ def solve_study(
                 for patch in patch_batch
             ]
         )
-        measurement_mask_batch = torch.stack(
-            [
-                study.measurement_mask[
-                    :,
-                    patch.y.start : patch.y.start + patch_size,
-                    patch.x.start : patch.x.start + patch_size,
-                ]
-                for patch in patch_batch
-            ]
-        )
 
         (
             objects,
@@ -310,7 +293,6 @@ def solve_study(
             batch_metrics,
         ) = _train_batch(
             measured_intensity_batch,
-            measurement_mask_batch,
             study.illumination_kx,
             study.illumination_ky,
             object_to_capture_ratio=object_to_capture_ratio,
@@ -323,7 +305,6 @@ def solve_study(
         solved_batches.append(
             _SolvedBatch(
                 patches=patch_batch,
-                reconstruction=objects.abs().square(),
                 object=objects,
             )
         )

--- a/src/ptych/core/synthetic.py
+++ b/src/ptych/core/synthetic.py
@@ -25,19 +25,18 @@ def synthesize_captures(
     Returns:
         Synthetic captures [illumination, height, width] as float intensities
     """
-    # Renormalize k-vectors from n-grid to N-grid
     illumination_kx = illumination_kx / object_to_capture_ratio
     illumination_ky = illumination_ky / object_to_capture_ratio
 
     # Run forward model at full resolution with one synthetic patch batch element.
     forward_model = FPMForwardModel(object_tensor.shape[-1]).to(object_tensor.device)
-    predicted_intensities = forward_model(
+    complex_image_fields = forward_model(
         object_tensor[None],
         pupil_tensor[None],
         illumination_kx,
         illumination_ky,
     )  # [1, illumination, object_height, object_width]
-    predicted_intensities = predicted_intensities.squeeze(0)
+    predicted_intensities = complex_image_fields.squeeze(0).abs().square()
 
     # Reduce full-resolution intensities to the capture grid with average pooling
     if object_to_capture_ratio > 1:

--- a/src/ptych/data/preprocess.py
+++ b/src/ptych/data/preprocess.py
@@ -62,7 +62,6 @@ def preprocess_study_data(
 ) -> tuple[
     list[Capture],
     Float[torch.Tensor, "illumination height width"],
-    Float[torch.Tensor, "illumination height width"],
     Float[torch.Tensor, "illumination"],
     Float[torch.Tensor, "illumination"],
 ]:
@@ -111,7 +110,6 @@ def preprocess_study_data(
         len(valid_captures), device=demosaiced_captures.device
     )
     captures_tensor = demosaiced_captures[capture_indices, channel_indices]
-    measurement_mask = torch.ones_like(captures_tensor)
     exposure_ms = torch.tensor(
         [_capture_exposure_ms(i, cap.exposure) for i, cap in enumerate(valid_captures)],
         dtype=captures_tensor.dtype,
@@ -128,7 +126,6 @@ def preprocess_study_data(
     return (
         valid_captures,
         captures_tensor / max_value,
-        measurement_mask,
         illumination_kx,
         illumination_ky,
     )

--- a/src/ptych/data/preprocess.py
+++ b/src/ptych/data/preprocess.py
@@ -62,6 +62,7 @@ def preprocess_study_data(
 ) -> tuple[
     list[Capture],
     Float[torch.Tensor, "illumination height width"],
+    Float[torch.Tensor, "illumination height width"],
     Float[torch.Tensor, "illumination"],
     Float[torch.Tensor, "illumination"],
 ]:
@@ -110,6 +111,7 @@ def preprocess_study_data(
         len(valid_captures), device=demosaiced_captures.device
     )
     captures_tensor = demosaiced_captures[capture_indices, channel_indices]
+    measurement_mask = torch.ones_like(captures_tensor)
     exposure_ms = torch.tensor(
         [_capture_exposure_ms(i, cap.exposure) for i, cap in enumerate(valid_captures)],
         dtype=captures_tensor.dtype,
@@ -123,4 +125,10 @@ def preprocess_study_data(
             "Prepared captures must contain at least one positive intensity value"
         )
 
-    return valid_captures, captures_tensor / max_value, illumination_kx, illumination_ky
+    return (
+        valid_captures,
+        captures_tensor / max_value,
+        measurement_mask,
+        illumination_kx,
+        illumination_ky,
+    )

--- a/src/ptych/data/study.py
+++ b/src/ptych/data/study.py
@@ -18,9 +18,6 @@ class PtychStudy:
     captures: Float[
         torch.Tensor, "illumination height width"
     ]  # Demosaiced, dark-subtracted, exposure-corrected scalar intensities normalized to max 1.
-    measurement_mask: Float[
-        torch.Tensor, "illumination height width"
-    ]  # One at valid sensor samples.
     illumination_kx: Float[
         torch.Tensor, "illumination"
     ]  # Normalized to camera grid (cycles per sample pixel).
@@ -33,14 +30,12 @@ class PtychStudy:
         manifest: StudyManifest,
         capture_metadata: list[Capture],
         captures: Float[torch.Tensor, "illumination height width"],
-        measurement_mask: Float[torch.Tensor, "illumination height width"],
         illumination_kx: Float[torch.Tensor, "illumination"],
         illumination_ky: Float[torch.Tensor, "illumination"],
     ):
         self.manifest = manifest
         self.capture_metadata = capture_metadata
         self.captures = captures
-        self.measurement_mask = measurement_mask
         self.illumination_kx = illumination_kx
         self.illumination_ky = illumination_ky
 
@@ -84,7 +79,6 @@ class PtychStudy:
         (
             capture_metadata,
             captures_tensor,
-            measurement_mask,
             illumination_kx,
             illumination_ky,
         ) = preprocess_study_data(
@@ -97,7 +91,6 @@ class PtychStudy:
             manifest=manifest,
             capture_metadata=capture_metadata,
             captures=captures_tensor,
-            measurement_mask=measurement_mask,
             illumination_kx=illumination_kx,
             illumination_ky=illumination_ky,
         )

--- a/src/ptych/data/study.py
+++ b/src/ptych/data/study.py
@@ -17,7 +17,10 @@ class PtychStudy:
     capture_metadata: list[Capture]
     captures: Float[
         torch.Tensor, "illumination height width"
-    ]  # Demosaiced, exposure-corrected single-channel float intensities normalized to max 1.
+    ]  # Demosaiced, dark-subtracted, exposure-corrected scalar intensities normalized to max 1.
+    measurement_mask: Float[
+        torch.Tensor, "illumination height width"
+    ]  # One at valid sensor samples.
     illumination_kx: Float[
         torch.Tensor, "illumination"
     ]  # Normalized to camera grid (cycles per sample pixel).
@@ -30,12 +33,14 @@ class PtychStudy:
         manifest: StudyManifest,
         capture_metadata: list[Capture],
         captures: Float[torch.Tensor, "illumination height width"],
+        measurement_mask: Float[torch.Tensor, "illumination height width"],
         illumination_kx: Float[torch.Tensor, "illumination"],
         illumination_ky: Float[torch.Tensor, "illumination"],
     ):
         self.manifest = manifest
         self.capture_metadata = capture_metadata
         self.captures = captures
+        self.measurement_mask = measurement_mask
         self.illumination_kx = illumination_kx
         self.illumination_ky = illumination_ky
 
@@ -79,6 +84,7 @@ class PtychStudy:
         (
             capture_metadata,
             captures_tensor,
+            measurement_mask,
             illumination_kx,
             illumination_ky,
         ) = preprocess_study_data(
@@ -91,6 +97,7 @@ class PtychStudy:
             manifest=manifest,
             capture_metadata=capture_metadata,
             captures=captures_tensor,
+            measurement_mask=measurement_mask,
             illumination_kx=illumination_kx,
             illumination_ky=illumination_ky,
         )


### PR DESCRIPTION
## Summary
This PR is a reconstruction-pipeline update, not just a narrow darkfield tweak. From the aggregate diff against `main`, it changes 10 tracked files: 234 insertions and 50 deletions.

- Add `src/ptych/core/darkfield.py` with modular `DarkfieldBackgrounds` and `DarkfieldScatter` components, including a darkfield illumination mask, positive softplus parameterization, per-illumination background terms, and rank-2 patch-local scatter.
- Wire the darkfield terms into `PtychographyModel` so predicted low-resolution intensities include coherent FPM intensity plus learned incoherent darkfield background/scatter.
- Change `FPMForwardModel` to return full-resolution complex image fields instead of intensities, so the main model can apply illumination gains in field/amplitude space before squaring and downsampling.
- Reparameterize `Object` amplitude as bounded sigmoid amplitude, initialized from the square root of the first capture and nearest-neighbor upsampling, with phase still initialized to zero.
- Update solver training around the final architecture: object LR `5e-3`, added optimizer groups for darkfield background/scatter, `weight_decay=0.0`, illumination chunking, direct sqrt-intensity residual, and no measurement floor/epsilon in the data term.
- Remove redundant solver state that stitched a separate intensity reconstruction alongside the complex object.
- Export the darkfield model components from `ptych.core`.
- Update the reconstruction demo defaults from `500` to `400` crop/patch size for the current evaluation workflow.
- Clarify study capture metadata as demosaiced, dark-subtracted, exposure-corrected scalar intensities; the preprocess diff itself is formatting-only.

## Verification
- `uv run ruff check src reconstruction_demo.py synthetic_demo.py`
- `uv run python -m compileall src synthetic_demo.py reconstruction_demo.py`

Experiment and ablation outputs were written under `results/` and are not included in this PR.